### PR TITLE
Add some parameters to the nexus::artifact class

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Usage
 		packaging => 'zip',
 		repository => "public-snapshots",
 		output => "/tmp/distribution-web-0.3.0-SNAPSHOT.zip",
-		timeout => 600
+		timeout => 600,
+		owner => 'myuser',
+		group => 'mygroup',
+		mode => 0755
 	}
 
 License

--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -10,6 +10,9 @@
 # [*output*] : The output file (mandatory)
 # [*ensure*] : If 'present' checks the existence of the output file (and downloads it if needed), if 'absent' deletes the output file, if not set redownload the artifact
 # [*timeout*] : Optional timeout for download exec. 0 disables - see exec for default.
+# [*owner*] : Optional user to own the file
+# [*group*] : Optional group to own the file
+# [*mode*] : Optional mode for file
 #
 # Actions:
 # If ensure is set to 'present' the resource checks the existence of the file and download the artifact if needed.
@@ -30,7 +33,10 @@ define nexus::artifact(
 	$repository,
 	$output,
 	$ensure = update,
-	$timeout = undef
+	$timeout = undef,
+  $owner = undef,
+  $group = undef,
+  $mode = undef
 	) {
 	
 	include nexus
@@ -64,4 +70,15 @@ define nexus::artifact(
 			timeout => $timeout
 		}
 	}
+
+    if $ensure != absent {
+      file { "${output}":
+        ensure => file,
+        require => Exec["Download ${gav}-${classifier}"],
+        owner => $owner,
+        group => $group,
+        mode => $mode
+      }
+    }
+
 }


### PR DESCRIPTION
Timeout is used to enable downloading large (or just slow) files.
Owner, group and mode are applied to the downloaded file whenever ensure != absent.
