### PR TITLE
Adds path to the line-endings exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ package { "dos2unix":
 }
 
 exec { "line-endings":
+	path    => '/bin:/usr/bin:/sbin',
   command => "dos2unix /opt/nexus-script/download-artifact-from-nexus.sh",
   require => [ Package["dos2unix"], File ["/opt/nexus-script/download-artifact-from-nexus.sh"] ]
 }


### PR DESCRIPTION
Adds the 'path' parameter to the 'line-endings' exec to fix the compilation error when running Rspec tests on a module that uses cescoffier/puppet-nexus.

Validation of Exec[line-endings] failed: 'dos2unix /opt/nexus-script/download-artifact-from-nexus.sh' is not qualified and no path was specified. Please qualify the command or specify a path
