### PR TITLE
maven classifier handling when undefined

### DIFF
--- a/manifests/artifact.pp
+++ b/manifests/artifact.pp
@@ -29,7 +29,7 @@ define nexus::artifact (
   $repository,
   $output,
   $packaging  = 'jar',
-  $classifier = '',
+  $classifier = undef,
   $ensure     = update,
   $timeout    = undef,
   $owner      = undef,
@@ -42,10 +42,10 @@ define nexus::artifact (
   if($nexus::username and $nexus::password) {
     $args = "-u ${nexus::username} -p '${nexus::password}'"
   } elsif ($nexus::netrc) {
-    $args = "-m"
+    $args = '-m'
   }
 
-  if ($classifier) {
+  if ($classifier!=undef) {
     $includeClass = "-c ${classifier}"
   }
 


### PR DESCRIPTION
The classifier -c '' string was being passed onto the command when not required i.e artifacts without any extra classifiers in nexus could not be downloaded via this module. The classifier parameter check is now correctly establishing whether it is defined or not and either includes or excludes the -c option from the eventual command.

Rationale for change http://grokbase.com/t/gg/puppet-users/147by1key3/checking-a-variable-is-not-undef

line 45, puppet lint issue fixed - single quotes necessary only