### PR TITLE
Add group to file resource for 'download-artifact-from-nexus.sh'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class nexus (
   file { '/opt/nexus-script/download-artifact-from-nexus.sh':
     ensure  => file,
     owner   => 'root',
+    group   => 'root',
     mode    => '0755',
     source  => 'puppet:///modules/nexus/download-artifact-from-nexus.sh',
     require => File['/opt/nexus-script']


### PR DESCRIPTION
Add group to file resource for 'download-artifact-from-nexus.sh'.

Fixes #32 